### PR TITLE
Make support for active state of auk-tabs__hierarchical-back consistent

### DIFF
--- a/_auk-tabs.scss
+++ b/_auk-tabs.scss
@@ -101,7 +101,8 @@
   margin: 0 0.6rem;
 }
 
-.auk-tabs__hierarchical-back a.active {
+.auk-tabs__hierarchical-back a.active,
+.auk-tabs__hierarchical-back.auk-tabs__tab--active a {
   color: $au-blue-600;
   border: none;
 }


### PR DESCRIPTION
Other places in the `_auk_tabs.scss`-file have support for the plain `active` class, as well as the `.auk-tabs__tab--active`-modifier. `.auk-tabs__hierarchical-back` didn't.

nb: imo the support for `active` was introduced plainly for facilitating dev implementation. Now the implementation uses the proper modifier, support for `active` may be dropped, since supporting 2 ways is confusing (as this PR illustrates). 