### PR TITLE
Replace deprecated shorthand 'color-adjust'

### DIFF
--- a/_auk-u-print.scss
+++ b/_auk-u-print.scss
@@ -23,7 +23,7 @@
   }
 
   .auk-u-keep-colors\@print {
-    color-adjust: exact;
+    print-color-adjust: exact;
     -webkit-print-color-adjust: exact;
   }
 


### PR DESCRIPTION
This came up during ember upgrade:

`autoprefixer: /app/assets/frontend-kaleidos.css:14314:5: Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated`

Traced back one occurrence of the deprecated shorthand `color-adjust` to this repo.

